### PR TITLE
add slideshow timeout setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,5 +32,3 @@ dist/*
 
 # ignore drawing of statemachine
 diagram_ProcessingPicture.png
-
-node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ dist/*
 
 # ignore drawing of statemachine
 diagram_ProcessingPicture.png
+

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ dist/*
 # ignore drawing of statemachine
 diagram_ProcessingPicture.png
 
+node_modules

--- a/photobooth/services/config/groups/uisettings.py
+++ b/photobooth/services/config/groups/uisettings.py
@@ -7,7 +7,7 @@ Remember to keep the settings in sync! Fields added here need to be added to the
 """
 
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, validator
 
 from .mediaprocessing import EnumPilgramFilter
 
@@ -53,6 +53,18 @@ class GroupUiSettings(BaseModel):
         default=True,
         description="Show button to admin center, usually only during setup.",
     )
+
+    show_automatic_slideshow_timeout: int = Field(
+        default=300, description="Timeout (seconds) after which a random order slideshow of all images is started. Set to 0 to disable."
+    )
+
+    @validator("show_automatic_slideshow_timeout")
+    def allow_zero_or_large(cls, v):
+        if v < 0:
+            raise ValueError("ensure this value is not negative")
+        if v > 0 and v < 30:
+            raise ValueError("ensure this value is at least 30")
+        return v
 
     livestream_mirror_effect: bool = Field(
         default=True,


### PR DESCRIPTION
... and ignore node_modules folder

Timeout setting is validated to be either 0 or at least 30 to prevent the slideshow starting too quickly and messing with the actual control flow.