### PR TITLE
Add meta tags for iOS fullscreen (mobile web app): hide address bar, status bar color

### DIFF
--- a/photobooth/web_spa/index.html
+++ b/photobooth/web_spa/index.html
@@ -1,3 +1,21 @@
-<!DOCTYPE html><html><head><title>Photobooth-App</title><meta charset=utf-8><meta name=description content="photobooth-app frontend"><meta name=format-detection content="telephone=no"><meta name=msapplication-tap-highlight content=no><meta name=viewport content="user-scalable=no,initial-scale=1,maximum-scale=1,minimum-scale=1,width=device-width"><link rel=icon type=image/png sizes=128x128 href=/icons/favicon-128x128.png>  <script type="module" crossorigin src="/assets/index-BtrfCjc9.js"></script>
-  <link rel="stylesheet" crossorigin href="/assets/index-C1nEYT92.css">
-</head><body><div id=q-app></div></body></html>
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Photobooth-App</title>
+    <meta charset="utf-8" />
+    <meta name="description" content="photobooth-app frontend" />
+    <meta name="format-detection" content="telephone=no" />
+    <meta name="msapplication-tap-highlight" content="no" />
+    <meta name="viewport" content="user-scalable=no,initial-scale=1,maximum-scale=1,minimum-scale=1,width=device-width"/>
+    <!--iOS: Hiding Safari User Interface Components-->
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <!--iOS: Changing the Status Bar Appearance to Black-->
+    <meta name="apple-mobile-web-app-status-bar-style" content="black">
+    <link rel=icon type=image/png sizes=128x128 href=/icons/favicon-128x128.png>
+    <script type="module" crossorigin src="/assets/index-BtrfCjc9.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-C1nEYT92.css" />
+  </head>
+  <body>
+    <div id="q-app"></div>
+  </body>
+</html>


### PR DESCRIPTION
This will add the ability to use the photobooth-app as fullscreen app when exported as web-clip:
Safari>Share>Add to Homescreen

The address bar is hidden and the status bar is set to black.