### PR TITLE
GPIO Light Plugin : Multi gpio light control and option to customize "active_high"

### DIFF
--- a/src/photobooth/plugins/gpio_lights/config.py
+++ b/src/photobooth/plugins/gpio_lights/config.py
@@ -17,6 +17,10 @@ class GpioLightsConfig(BaseConfig):
         default=2,
         description="First GPIO pin to control a light.",
     )
+    active_high: bool = Field(
+        default=False,
+        description="Set to True if the GPIO pin is active high, False if it is active low.",
+    )
     gpio_pin_light2: int = Field(
         default=12,
         description="Second GPIO pin to control a light (leave empty if not used).",

--- a/src/photobooth/plugins/gpio_lights/config.py
+++ b/src/photobooth/plugins/gpio_lights/config.py
@@ -15,7 +15,15 @@ class GpioLightsConfig(BaseConfig):
 
     gpio_pin_light: int = Field(
         default=2,
-        description="GPIO pin to control a light.",
+        description="First GPIO pin to control a light.",
+    )
+    gpio_pin_light2: int = Field(
+        default=12,
+        description="Second GPIO pin to control a light (leave empty if not used).",
+    )
+    gpio_pin_light3: int = Field(
+        default=13,
+        description="Third GPIO pin to control a light (leave empty if not used).",
     )
     gpio_light_off_after_capture: bool = Field(
         default=True,

--- a/src/photobooth/plugins/gpio_lights/config.py
+++ b/src/photobooth/plugins/gpio_lights/config.py
@@ -1,4 +1,4 @@
-from pydantic import Field
+from pydantic import AliasChoices, Field, field_validator
 from pydantic_settings import SettingsConfigDict
 
 from photobooth import CONFIG_PATH
@@ -18,7 +18,17 @@ class GpioLightsConfig(BaseConfig):
             2,
         ],
         description="List of GPIO pins to control lights. The first pin is mandatory, the others are optional. ",
+        validation_alias=AliasChoices("gpio_pin_light_list", "gpio_pin_light"),
     )
+
+    # Ensures that the old format single pin attribute is converted to a list
+    @field_validator("gpio_pin_light_list", mode="before")
+    @classmethod
+    def convert_single_pin_to_list(cls, value):
+        if isinstance(value, int):
+            return [value]
+        return value
+
     active_high: bool = Field(
         default=False,
         description="Set to True if the GPIO pin is active high, False if it is active low.",

--- a/src/photobooth/plugins/gpio_lights/config.py
+++ b/src/photobooth/plugins/gpio_lights/config.py
@@ -21,11 +21,11 @@ class GpioLightsConfig(BaseConfig):
         default=False,
         description="Set to True if the GPIO pin is active high, False if it is active low.",
     )
-    gpio_pin_light2: int = Field(
-        default=12,
+    gpio_pin_light2: int | None = Field(
+        default=None,
         description="Second GPIO pin to control a light (leave empty if not used).",
     )
-    gpio_pin_light3: int = Field(
+    gpio_pin_light3: int | None = Field(
         default=13,
         description="Third GPIO pin to control a light (leave empty if not used).",
     )

--- a/src/photobooth/plugins/gpio_lights/config.py
+++ b/src/photobooth/plugins/gpio_lights/config.py
@@ -13,21 +13,15 @@ class GpioLightsConfig(BaseConfig):
         description="Enable to start the plugin with app startup",
     )
 
-    gpio_pin_light: int = Field(
-        default=2,
-        description="First GPIO pin to control a light.",
+    gpio_pin_light_list: list[int] = Field(
+        default_factory=lambda: [
+            2,
+        ],
+        description="List of GPIO pins to control lights. The first pin is mandatory, the others are optional. ",
     )
     active_high: bool = Field(
         default=False,
         description="Set to True if the GPIO pin is active high, False if it is active low.",
-    )
-    gpio_pin_light2: int | None = Field(
-        default=None,
-        description="Second GPIO pin to control a light (leave empty if not used).",
-    )
-    gpio_pin_light3: int | None = Field(
-        default=13,
-        description="Third GPIO pin to control a light (leave empty if not used).",
     )
     gpio_light_off_after_capture: bool = Field(
         default=True,

--- a/src/photobooth/plugins/gpio_lights/gpio_lights.py
+++ b/src/photobooth/plugins/gpio_lights/gpio_lights.py
@@ -16,7 +16,7 @@ class GpioLights(BasePlugin[GpioLightsConfig]):
         super().__init__()
 
         self._config: GpioLightsConfig = GpioLightsConfig()
-        self.light_out: list[DigitalOutputDevice | None]
+        self.light_out_list: list[DigitalOutputDevice | None]
 
     @hookimpl
     def start(self):
@@ -59,20 +59,20 @@ class GpioLights(BasePlugin[GpioLightsConfig]):
 
     def init_io(self):
         # shutdown
-        self.light_out[0] = DigitalOutputDevice(self._config.gpio_pin_light, active_high=False)
+        self.light_out_list[0] = DigitalOutputDevice(self._config.gpio_pin_light, active_high=False)
         if self._config.gpio_pin_light2:
-            self.light_out[1] = DigitalOutputDevice(self._config.gpio_pin_light2, active_high=False)
+            self.light_out_list[1] = DigitalOutputDevice(self._config.gpio_pin_light2, active_high=False)
         if self._config.gpio_pin_light3:
-            self.light_out[2] = DigitalOutputDevice(self._config.gpio_pin_light3, active_high=False)
+            self.light_out_list[2] = DigitalOutputDevice(self._config.gpio_pin_light3, active_high=False)
 
     def uninit_io(self):
-        for light_out in self.light_out:
+        for light_out in self.light_out_list:
             if light_out:
                 light_out.close()
                 light_out = None
 
     def light(self, on: bool):
-        for light_out in self.light_out:
+        for light_out in self.light_out_list:
             if light_out:
                 try:
                     light_out.on() if on else light_out.off()

--- a/src/photobooth/plugins/gpio_lights/gpio_lights.py
+++ b/src/photobooth/plugins/gpio_lights/gpio_lights.py
@@ -16,7 +16,7 @@ class GpioLights(BasePlugin[GpioLightsConfig]):
         super().__init__()
 
         self._config: GpioLightsConfig = GpioLightsConfig()
-        self.light_out_list: list[DigitalOutputDevice | None]
+        self.light_out_list: list[DigitalOutputDevice | None] = [None] * 3
 
     @hookimpl
     def start(self):

--- a/src/photobooth/plugins/gpio_lights/gpio_lights.py
+++ b/src/photobooth/plugins/gpio_lights/gpio_lights.py
@@ -16,7 +16,7 @@ class GpioLights(BasePlugin[GpioLightsConfig]):
         super().__init__()
 
         self._config: GpioLightsConfig = GpioLightsConfig()
-        self.light_out_list: list[DigitalOutputDevice | None] = [None] * 3
+        self.light_out_list: list[DigitalOutputDevice | None] = []
 
     @hookimpl
     def start(self):
@@ -59,11 +59,8 @@ class GpioLights(BasePlugin[GpioLightsConfig]):
 
     def init_io(self):
         # shutdown
-        self.light_out_list[0] = DigitalOutputDevice(self._config.gpio_pin_light, active_high=self._config.active_high)
-        if self._config.gpio_pin_light2:
-            self.light_out_list[1] = DigitalOutputDevice(self._config.gpio_pin_light2, active_high=self._config.active_high)
-        if self._config.gpio_pin_light3:
-            self.light_out_list[2] = DigitalOutputDevice(self._config.gpio_pin_light3, active_high=self._config.active_high)
+        for gpio_pin_light in self._config.gpio_pin_light_list:
+            self.light_out_list.append(DigitalOutputDevice(gpio_pin_light, active_high=self._config.active_high))
 
     def uninit_io(self):
         for light_out in self.light_out_list:

--- a/src/photobooth/plugins/gpio_lights/gpio_lights.py
+++ b/src/photobooth/plugins/gpio_lights/gpio_lights.py
@@ -16,7 +16,7 @@ class GpioLights(BasePlugin[GpioLightsConfig]):
         super().__init__()
 
         self._config: GpioLightsConfig = GpioLightsConfig()
-        self.light_out_list: list[DigitalOutputDevice | None] = []
+        self.light_out_list: list[DigitalOutputDevice] = []
 
     @hookimpl
     def start(self):

--- a/src/photobooth/plugins/gpio_lights/gpio_lights.py
+++ b/src/photobooth/plugins/gpio_lights/gpio_lights.py
@@ -59,11 +59,11 @@ class GpioLights(BasePlugin[GpioLightsConfig]):
 
     def init_io(self):
         # shutdown
-        self.light_out_list[0] = DigitalOutputDevice(self._config.gpio_pin_light, active_high=False)
+        self.light_out_list[0] = DigitalOutputDevice(self._config.gpio_pin_light, active_high=self._config.active_high)
         if self._config.gpio_pin_light2:
-            self.light_out_list[1] = DigitalOutputDevice(self._config.gpio_pin_light2, active_high=False)
+            self.light_out_list[1] = DigitalOutputDevice(self._config.gpio_pin_light2, active_high=self._config.active_high)
         if self._config.gpio_pin_light3:
-            self.light_out_list[2] = DigitalOutputDevice(self._config.gpio_pin_light3, active_high=False)
+            self.light_out_list[2] = DigitalOutputDevice(self._config.gpio_pin_light3, active_high=self._config.active_high)
 
     def uninit_io(self):
         for light_out in self.light_out_list:

--- a/src/photobooth/plugins/gpio_lights/gpio_lights.py
+++ b/src/photobooth/plugins/gpio_lights/gpio_lights.py
@@ -66,13 +66,15 @@ class GpioLights(BasePlugin[GpioLightsConfig]):
             self.light_out[2] = DigitalOutputDevice(self._config.gpio_pin_light3, active_high=False)
 
     def uninit_io(self):
-        if self.light_out:
-            self.light_out.close()
-            self.light_out = None
+        for light_out in self.light_out:
+            if light_out:
+                light_out.close()
+                light_out = None
 
     def light(self, on: bool):
-        if self.light_out:
-            try:
-                self.light_out.on() if on else self.light_out.off()
-            except Exception as exc:
-                logger.error(f"could not switch light, error: {exc}")
+        for light_out in self.light_out:
+            if light_out:
+                try:
+                    light_out.on() if on else light_out.off()
+                except Exception as exc:
+                    logger.error(f"could not switch light, error: {exc}")

--- a/src/photobooth/plugins/gpio_lights/gpio_lights.py
+++ b/src/photobooth/plugins/gpio_lights/gpio_lights.py
@@ -16,7 +16,7 @@ class GpioLights(BasePlugin[GpioLightsConfig]):
         super().__init__()
 
         self._config: GpioLightsConfig = GpioLightsConfig()
-        self.light_out: DigitalOutputDevice | None = None
+        self.light_out: list[DigitalOutputDevice | None]
 
     @hookimpl
     def start(self):
@@ -59,7 +59,11 @@ class GpioLights(BasePlugin[GpioLightsConfig]):
 
     def init_io(self):
         # shutdown
-        self.light_out = DigitalOutputDevice(self._config.gpio_pin_light, active_high=False)
+        self.light_out[0] = DigitalOutputDevice(self._config.gpio_pin_light, active_high=False)
+        if self._config.gpio_pin_light2:
+            self.light_out[1] = DigitalOutputDevice(self._config.gpio_pin_light2, active_high=False)
+        if self._config.gpio_pin_light3:
+            self.light_out[2] = DigitalOutputDevice(self._config.gpio_pin_light3, active_high=False)
 
     def uninit_io(self):
         if self.light_out:

--- a/src/tests/tests/plugins/test_gpio_lights.py
+++ b/src/tests/tests/plugins/test_gpio_lights.py
@@ -7,7 +7,7 @@ import pytest
 from gpiozero.pins.mock import MockPin
 
 from photobooth.container import Container, container
-from photobooth.plugins.gpio_lights.gpio_lights import GpioLights
+from photobooth.plugins.gpio_lights.gpio_lights import GpioLights, GpioLightsConfig
 
 from ..util import get_impl_func_for_plugin
 
@@ -23,6 +23,17 @@ def _container() -> Generator[Container, None, None]:
     container.start()
     yield container
     container.stop()
+
+
+def test_gpio_pin_light_migration(_container):
+    """
+    Migration from old gpio_pin_light (int) attr
+    to new gpio_pin_light_list (list of int) attr.
+    Also checks that old attr is removed from config.
+    """
+    config = GpioLightsConfig.model_validate({"gpio_pin_light": 5})
+    assert config.gpio_pin_light_list == [5]
+    assert not hasattr(config, "gpio_pin_light")
 
 
 def test_hooks_integration(_container: Container):

--- a/src/tests/tests/plugins/test_gpio_lights.py
+++ b/src/tests/tests/plugins/test_gpio_lights.py
@@ -40,39 +40,50 @@ def test_hooks_integration(_container: Container):
 def test_light_switched_during_process(_container: Container):
     gpio_lights_plugin = cast(GpioLights, _container.pluginmanager_service.get_plugin("photobooth.plugins.gpio_lights.gpio_lights"))
 
-    assert gpio_lights_plugin.light_out
-    pin = cast(MockPin, gpio_lights_plugin.light_out.pin)
-    pin.clear_states()
+    assert gpio_lights_plugin.light_out_list
+
+    for light_out in gpio_lights_plugin.light_out_list:
+        pin = cast(MockPin, light_out.pin)
+        pin.clear_states()
 
     _container.processing_service.trigger_action("image", 0)
     _container.processing_service.wait_until_job_finished()
 
     # could use also pin.assert_states but strict is false and so it would not fail if more states are present.
-    for actual, expected in zip(pin.states, [True, False, True], strict=True):
-        assert actual.state == expected
+    for light_out in gpio_lights_plugin.light_out_list:
+        pin = cast(MockPin, light_out.pin)
+        for actual, expected in zip(pin.states, [True, False, True], strict=True):
+            assert actual.state == expected
 
 
 def test_light_switched_during_process_turn_off_after_capture(_container: Container):
     gpio_lights_plugin = cast(GpioLights, _container.pluginmanager_service.get_plugin("photobooth.plugins.gpio_lights.gpio_lights"))
     gpio_lights_plugin._config.gpio_light_off_after_capture = True
 
-    assert gpio_lights_plugin.light_out
-    pin = cast(MockPin, gpio_lights_plugin.light_out.pin)
-    pin.clear_states()
+    assert gpio_lights_plugin.light_out_list
+
+    for light_out in gpio_lights_plugin.light_out_list:
+        pin = cast(MockPin, light_out.pin)
+        pin.clear_states()
 
     _container.processing_service.trigger_action("collage", 0)
     _container.processing_service.wait_until_job_finished()
 
     # could use also pin.assert_states but strict is false and so it would not fail if more states are present.
-    for actual, expected in zip(pin.states, [True, False, True, False, True], strict=True):
-        assert actual.state == expected
+    for light_out in gpio_lights_plugin.light_out_list:
+        pin = cast(MockPin, light_out.pin)
+        for actual, expected in zip(pin.states, [True, False, True, False, True], strict=True):
+            assert actual.state == expected
+
+        pin.clear_states()
 
     gpio_lights_plugin._config.gpio_light_off_after_capture = False
-    pin.clear_states()
 
     _container.processing_service.trigger_action("collage", 0)
     _container.processing_service.wait_until_job_finished()
 
     # could use also pin.assert_states but strict is false and so it would not fail if more states are present.
-    for actual, expected in zip(pin.states, [True, False, True], strict=True):
-        assert actual.state == expected
+    for light_out in gpio_lights_plugin.light_out_list:
+        pin = cast(MockPin, light_out.pin)
+        for actual, expected in zip(pin.states, [True, False, True], strict=True):
+            assert actual.state == expected


### PR DESCRIPTION
Hello,
Original plugin didn't work for me. In my setup :
- 2 pins control led strips : 1 for "cold" led strip and 1 for "warm" led strip.
- pins active low

Rather than creating a new plugin, I updated the original one :
- updated gpio_pin_light into a list so we can have 1 or more pins to control light
- added a boolean option to customize "active_high"

Feel free to merge this update or tell me if it would be better to create a new plugin.

Thanks a lot for this great PhotoBooth app :-)
Jean-Sébastien