### PR TITLE
synchronizer_rclone: implement upload_only

### DIFF
--- a/src/photobooth/plugins/synchronizer_rclone/config.py
+++ b/src/photobooth/plugins/synchronizer_rclone/config.py
@@ -131,6 +131,10 @@ class RemoteConfig(BaseModel):
         default=True,
         description="Copy the sharepage-file (index.html) to the remote on startup.",
     )
+    upload_only: bool = Field(
+        default=False,
+        description="Only upload files to this remote. Deleted local files stay on the remote.",
+    )
 
     shareconfig: ShareConfig
 

--- a/src/photobooth/plugins/synchronizer_rclone/immediate_synchronizer.py
+++ b/src/photobooth/plugins/synchronizer_rclone/immediate_synchronizer.py
@@ -93,9 +93,11 @@ class ThreadedImmediateSyncPipeline:
                 op = CopyOperation(
                     str(Path.cwd().absolute()), f"{task.file}", r.name, Path(r.subdir, get_corresponding_remote_file(task.file)).as_posix()
                 )
-            elif isinstance(task, TaskDelete):
+            elif isinstance(task, TaskDelete) and not r.upload_only:
                 op = DeleteOperation(r.name, Path(r.subdir, get_corresponding_remote_file(task.file)).as_posix())
-            # else never as per typing
+            else:
+                logger.info(f"no operation found for remote '{r.name}' and task '{task!r}' (upload only: {r.upload_only})")
+                continue
 
             job_id = next(self._job_counter)
             job = PrioritizedJob(priority=priority, job_id=job_id, operation=op)

--- a/src/photobooth/plugins/synchronizer_rclone/regular_synchronizer.py
+++ b/src/photobooth/plugins/synchronizer_rclone/regular_synchronizer.py
@@ -60,10 +60,18 @@ class ThreadedRegularSync:
             full_sync_jobids: list[int] = []
 
             for remote in self.remotes:
-                job = self.rclone.sync_async(
-                    str(Path(MEDIA_PATH).absolute()),
-                    f"{remote.name}{Path(remote.subdir, get_corresponding_remote_file(Path(MEDIA_PATH))).as_posix()}",
-                )
+                if remote.upload_only:
+                    logger.info(f"copy files to remote '{remote.name}'")
+                    job = self.rclone.copy_async(
+                        str(Path(MEDIA_PATH).absolute()),
+                        f"{remote.name}{Path(remote.subdir, get_corresponding_remote_file(Path(MEDIA_PATH))).as_posix()}",
+                    )
+                else:
+                    logger.info(f"sync files with '{remote.name}'")
+                    job = self.rclone.sync_async(
+                        str(Path(MEDIA_PATH).absolute()),
+                        f"{remote.name}{Path(remote.subdir, get_corresponding_remote_file(Path(MEDIA_PATH))).as_posix()}",
+                    )
 
                 full_sync_jobids.append(job.jobid)
 

--- a/src/tests/tests/plugins/test_synchronizer_rclone.py
+++ b/src/tests/tests/plugins/test_synchronizer_rclone.py
@@ -4,8 +4,11 @@ from uuid import uuid4
 
 import pytest
 
-from photobooth.plugins.synchronizer_rclone.config import SynchronizerConfig
+from photobooth.plugins.synchronizer_rclone.config import RemoteConfig, ShareConfig, SynchronizerConfig
+from photobooth.plugins.synchronizer_rclone.immediate_synchronizer import ThreadedImmediateSyncPipeline
+from photobooth.plugins.synchronizer_rclone.regular_synchronizer import ThreadedRegularSync
 from photobooth.plugins.synchronizer_rclone.synchronizer_rclone import SynchronizerRclone
+from photobooth.plugins.synchronizer_rclone.types import DeleteOperation, TaskDelete
 
 
 @pytest.fixture(scope="function")
@@ -155,3 +158,41 @@ def test_collection_hooks(sync: SynchronizerRclone):
         sync.collection_files_deleted([f])
 
         assert mock_put.call_count == 3
+
+
+def test_immediateSnycPipeline_skip_delete_op_when_upload_only_is_enabled():
+    remotes = [
+        RemoteConfig(enabled=True, description="backup", name="backup:", subdir="archive", upload_only=True, shareconfig=ShareConfig()),
+        RemoteConfig(enabled=True, description="sync", name="sync:", subdir="archive", upload_only=False, shareconfig=ShareConfig()),
+    ]
+
+    pipeline = ThreadedImmediateSyncPipeline(rclone=MagicMock(), remotes=remotes, max_concurrency=0)
+    pipeline.submit(TaskDelete(Path("media/test.jpg")), priority=19)
+
+    assert len(pipeline.results) == 1
+    assert pipeline.queue.qsize() == 1
+
+    queued_job = pipeline.queue.get_nowait()
+    assert isinstance(queued_job.operation, DeleteOperation)
+    assert queued_job.operation.dst_fs == "sync:"
+    assert queued_job.operation.dst_remote == "archive/media/test.jpg"
+
+
+def test_regularSync_uses_copy_for_upload_only_remotes():
+    remotes = [
+        RemoteConfig(enabled=True, description="backup", name="backup:", subdir="archive", upload_only=True, shareconfig=ShareConfig()),
+        RemoteConfig(enabled=True, description="sync", name="sync:", subdir="archive", upload_only=False, shareconfig=ShareConfig()),
+    ]
+
+    rclone = MagicMock()
+    rclone.copy_async.return_value = MagicMock(jobid=11)
+    rclone.sync_async.return_value = MagicMock(jobid=22)
+
+    regular_sync = ThreadedRegularSync(rclone=rclone, fullsync_remotes=remotes, sync_interval_s=999)
+    regular_sync._worker.join(timeout=1)
+    regular_sync.stop()
+
+    assert rclone.copy_async.call_count == 1
+    assert rclone.sync_async.call_count == 1
+    assert rclone.wait_for_jobs.call_count == 1
+    assert rclone.wait_for_jobs.call_args.args[0] == [11, 22]


### PR DESCRIPTION
# Contribution

## Motivation

I only use the photobooth-app online. All media are deleted after use via the corresponding function. The synced media must be backed up beforehand; if this isn’t done, everything will be lost. That’s a major risk.

Similar to the Recycle Bin, I want to prevent media from being lost. 


## Changes

- add new property: upload_only
- immediate_synchronizer: skips deletion if upload_only == true
- regular_synchronizer: use copy_async if upload_only == true

## Testing

There are two new unit tests.

For my manual tests, I created two remotes. One with `Upload Only = true`, and one with `Upload Only = false`.
I set the full sync interval to 1 minute.


Then I took a photo. 
Once synced, I deleted the photo from the gallery.

Result: The photo is still present on one remote.

Then I took another photo.
Once synced, use the “Delete All Media” function.
Wait until the full sync has completed.

Result: One remote contains 2 photos, the other contains none

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/photobooth-app/photobooth-app/blob/main/CONTRIBUTING.md).
- [x] Code follows project style guidelines (At least, I hope so)
- [x] Tests added or updated
- [x] Documentation updated if needed (I haven't found any documentation that I need to customize)

## Is there anything you'd like reviewers to focus on?

---

## AI used to create this Pull Request?

I only used AI while writing the unit tests.