### PR TITLE
fix: handle temp BlockingIOError on macOS camera stream init

### DIFF
--- a/src/photobooth/services/backends/webcampyav.py
+++ b/src/photobooth/services/backends/webcampyav.py
@@ -115,16 +115,33 @@ class WebcamPyavBackend(AbstractBackend):
                 logger.info(f"pyav packet received: {next(input_device.demux())}")
                 logger.info(f"livestream resolution: {rW}x{rH}")
 
-                try:
-                    frame = next(input_device.decode(input_stream))
-                    logger.info(f"pyav frame received: {frame}")
-                    logger.info(f"frame format: {frame.format}")
-                except Exception as exc:
-                    raise PermanentFault("Error decoding camera frame! Ensure the settings are correct (device name, fps, resolution, ...)") from exc
+                # wait for first frame. macos might return eagain (BlockingIOError) initially
+                while not self._stop_event.is_set():
+                    try:
+                        frame = next(input_device.decode(input_stream))
+                        logger.info(f"pyav frame received: {frame}")
+                        logger.info(f"frame format: {frame.format}")
+                        break
+                    except BlockingIOError:
+                        time.sleep(0.01)
+                        continue
+                    except Exception as exc:
+                        raise PermanentFault(
+                            "Error decoding camera frame! Ensure the settings are correct (device name, fps, resolution, ...)"
+                        ) from exc
 
                 codec_name = input_stream.codec.name
 
-                for frame in input_device.decode(input_stream):
+                def _frame_generator(device, stream):
+                    # wrapper to catch temporary eagain on macos without breaking the loop
+                    while not self._stop_event.is_set():
+                        try:
+                            yield from device.decode(stream)
+                            break
+                        except BlockingIOError:
+                            continue
+
+                for frame in _frame_generator(input_device, input_stream):
                     with self._hires_lock:
                         req = self._hires_queue.popleft() if self._hires_queue else None
 


### PR DESCRIPTION
# Contribution
With current implementation, in macOS a pyAV backend will only show one frame and stop there.
This is a small fix to stabilize pyAV capabilities in macOS.

## Motivation
The app runs nearly 100% under macOS.
This PR will fix following Error when using pyAV under macOS:

av.error.BlockingIOError: [Errno 35] Resource temporarily unavailable: 'MacBook\xa0Air-Kamera'; last error log: [avfoundation] bgr0
2026-06-04 18:48:05,222 [CRITICAL] service crashed, error: [Errno 35] Resource temporarily unavailable: 'MacBook\xa0Air-Kamera'; last error log: [avfoundation] bgr0 (resilientservice.py:52)

## Changes
- Add retry logic for initial frame fetch to handle temporary EAGAIN (BlockingIOError) on macOS
- Introduce generator wrapper `_frame_generator()` to gracefully handle BlockingIOError during video stream decoding without breaking the main loop
- Add brief sleep on EAGAIN during initialization to avoid busy-waiting

## Testing

Tested running in Python 3.13 on macOS 26.
Tested with internal and external Webcams.
Tested different frame rates.
Tested Preview Resolution Reduce Factor.

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/photobooth-app/photobooth-app/blob/main/CONTRIBUTING.md).
- [x] Code follows project style guidelines
- [ ] Tests added or updated
- [ ] Documentation updated if needed

## AI used to create this Pull Request?

Yes, this is implemented with the help of Gemini.
I focused on following the project style as good as possible.